### PR TITLE
Added link of Angular Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ By Brad Green and Shyam Seshadri
 ## Cheat Sheets
 
 [Cheat Sheet](http://www.cheatography.com/proloser/cheat-sheets/angularjs/)
+[Angular Developer Roadmap](https://roadmap.sh/angular)
 
 ## Slides
 


### PR DESCRIPTION
Hi @kahlil,

I came across your repository [angular-resources](https://github.com/kahlil/angular-resources) and found it to be a valuable resource for Angular enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Angular Developer Roadmap"](https://roadmap.sh/angular). I took the initiative to submit a ["Pull Request"](https://github.com/kahlil/angular-resources/pull/17) adding it in "Cheatsheet" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz